### PR TITLE
Update Chp1-Ex2.cpp

### DIFF
--- a/Chapter01/Chp1-Ex2.cpp
+++ b/Chapter01/Chp1-Ex2.cpp
@@ -10,14 +10,20 @@ using std::endl;
 using std::flush;
 using std::setw;
 using std::setprecision;
+using std::numeric_limits;
+using std::streamsize;
 
 int main()
 {
     char name[20];   // caution; unitialized array of char
     float gpa = 0.0;
-    cout << "Please enter a name and a gpa: ";
+    cout << "Please enter a name:";
     // Now, we won't overflow the input buffer of name (by using setw) 
-    cin >> setw(20) >> name >> gpa;
+    cin >> setw(20) >> name;
+    // Clear the input buffer
+    cin.ignore(numeric_limits<streamsize>::max(), '\n');
+    cout << "Please enter a GPA: ";
+    cin >> gpa;
     cout << "Hello " << name << flush;
     cout << ". GPA is: " << setprecision(3) << gpa << endl;
     return 0;


### PR DESCRIPTION
A problem arises because when a user enters a name longer than 20 characters which results in leftover characters in the input stream. Since there are leftover characters in the buffer, cin cannot parse a valid float, and the operation fails and the value of gpa remains in its initialized value of 0.0

The setw(20) manipulator in C++ limits how many characters are extracted from the input stream and stored in the provided buffer (in this case, name). However, it does not consume nor remove any characters beyond this limit from the input buffer. 

To fix this issue, we can clear the input stream after reading the name to ensure there are no leftover characters.